### PR TITLE
Allow anonymous users to see comments

### DIFF
--- a/src/ui/components/Video.tsx
+++ b/src/ui/components/Video.tsx
@@ -55,7 +55,7 @@ function Video({
     }
   };
 
-  const showCommentTool = isPaused && !isNodeTarget && isAuthenticated && !isNodePickerActive;
+  const showCommentTool = isPaused && !isNodeTarget && !isNodePickerActive;
 
   return (
     <div id="video">


### PR DESCRIPTION
Addresses https://github.com/RecordReplay/devtools/issues/3722

I'm guessing at some point there was not a good UI state to handle an anonmyous user attempting to leave a comment, but it seems like there is now, so it's safe to show everyone the comment interface.